### PR TITLE
Allow precaching the mavenbuild with a tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ RUN JAVA_32=$(alternatives --display java | awk '/family.*i386/{print $1}') && \
 
 RUN mkdir /root/workspaces
 WORKDIR /root/workspaces
-CMD sleep infinity
+COPY maven-cache.sh .
+CMD ["/bin/bash","maven-cache.sh"]

--- a/maven-cache.sh
+++ b/maven-cache.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# check if maven dependencies are cached by previous build
+# if its then it downloads the prebuild cache from online source
+# MAVEN_CACHE_TAR_URL : The prebuilt tarball URL as tar.gz where all dependencies are located
+set -x
+
+if [[ -n ${MAVEN_CACHE_TAR_URL} && ! -d /root/.mvnrepository/repository ]]; then
+    echo "Downloading the prebuilt maven cache\n"
+	MAVEN_CACHE_TAR_FILE=$(basename ${MAVEN_CACHE_TAR_URL})
+
+    curl -L ${MAVEN_CACHE_TAR_URL} -o /tmp/${MAVEN_CACHE_TAR_FILE} \
+        && tar -xvzf /tmp/${MAVEN_CACHE_TAR_FILE} -C /tmp \
+        && mv /tmp/repository /root/.mvnrepository \
+        && rm -rf /tmp/${MAVEN_CACHE_TAR_FILE}
+fi
+exec sleep infinity


### PR DESCRIPTION
If you have a MAVEN_CACHE_TAR_URL we will use it to prefill the maven cache.