### PR TITLE
OSIO boosters precaching dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ RUN curl -L http://central.maven.org/maven2/io/fabric8/updatebot/updatebot/$UPDA
 RUN mkdir /root/workspaces
 WORKDIR /root/workspaces
 COPY maven-cache.sh .
-CMD ["/bin/bash","maven-cache.sh"]
+CMD ["/bin/sh","maven-cache.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,5 @@ RUN curl -L http://central.maven.org/maven2/io/fabric8/updatebot/updatebot/$UPDA
 
 RUN mkdir /root/workspaces
 WORKDIR /root/workspaces
-CMD sleep infinity
+COPY maven-cache.sh .
+CMD ["/bin/bash","maven-cache.sh"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-# builder-maven
+# Maven Builder
 
-Builder image used by kubernetes-workflow to run java maven builds
+Builder image used by kubernetes-workflow to execute Java maven builds
+
+
+# Configuration:
+ * *Maven Caching*: Allows building local maven repository with predefined set of dependencies on container boot up. Following are the ENV variables to configure this option
+ 	* MAVEN_CACHE_ENABLE: Set `true`  to enable maven caching feature. By default its disabled.
+ 	* MAVEN_CACHE_TAR_URL: URL to download tarball containing predefined set of dependencies required for maven build. e.g. https://s3.us-east-2.amazonaws.com/build-artifacts.tar.gz. URL must have the tarball file name like `build-artifacts.tar.gz` in given example.
+    * MAVEN__LOCAL_REPOSITORY_PATH: Local maven repository path. Doesn't consider default path (/home/.m2)

--- a/maven-cache.sh
+++ b/maven-cache.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
 # check if maven dependencies are cached by previous build
-# if its then it downloads the prebuild cache from online source
+# if not then it downloads the prebuilt cache from online source
+# MAVEN_CACHE_ENABLE : To enable maven prebuild caching
 # MAVEN_CACHE_TAR_URL : The prebuilt tarball URL as tar.gz where all dependencies are located
-set -x
+# MAVEN__LOCAL_REPOSITORY_PATH: Local maven repository path
 
-if [[ -n ${MAVEN_CACHE_TAR_URL} && ! -d /root/.mvnrepository/repository ]]; then
+if [[ -n ${MAVEN_CACHE_ENABLE} && ${MAVEN_CACHE_ENABLE} == "true" && -n ${MAVEN_CACHE_TAR_URL} && \
+      -n ${MAVEN__LOCAL_REPOSITORY_PATH} && -d ${MAVEN__LOCAL_REPOSITORY_PATH} ]]; then
+
     echo "Downloading the prebuilt maven cache\n"
+
 	MAVEN_CACHE_TAR_FILE=$(basename ${MAVEN_CACHE_TAR_URL})
 
     curl -L ${MAVEN_CACHE_TAR_URL} -o /tmp/${MAVEN_CACHE_TAR_FILE} \
         && tar -xvzf /tmp/${MAVEN_CACHE_TAR_FILE} -C /tmp \
-        && mv /tmp/repository/* /root/.mvnrepository \
+        && restorecon -Rv /tmp/repository/ \
+        && mv /tmp/repository/* ${MAVEN__LOCAL_REPOSITORY_PATH} \
         && rm -rf /tmp/${MAVEN_CACHE_TAR_FILE}
 fi
-exec sleep infinity
+
+cat

--- a/maven-cache.sh
+++ b/maven-cache.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# check if maven dependencies are cached by previous build
+# if its then it downloads the prebuild cache from online source
+# MAVEN_CACHE_TAR_URL : The prebuilt tarball URL as tar.gz where all dependencies are located
+set -x
+
+if [[ -n ${MAVEN_CACHE_TAR_URL} && ! -d /root/.mvnrepository/repository ]]; then
+    echo "Downloading the prebuilt maven cache\n"
+	MAVEN_CACHE_TAR_FILE=$(basename ${MAVEN_CACHE_TAR_URL})
+
+    curl -L ${MAVEN_CACHE_TAR_URL} -o /tmp/${MAVEN_CACHE_TAR_FILE} \
+        && tar -xvzf /tmp/${MAVEN_CACHE_TAR_FILE} -C /tmp \
+        && mv /tmp/repository/* /root/.mvnrepository \
+        && rm -rf /tmp/${MAVEN_CACHE_TAR_FILE}
+fi
+exec sleep infinity


### PR DESCRIPTION
Precaching all maven dependencies required by OSIO boosters applications to reduce build time

Just wondering if this image is being used anywhere else apart from OSIO tenant Jenkins
@chmouel @rupalibehera @rohanKanojia 
 