### PR TITLE
Add a writable path for maven

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV M2_HOME /opt/apache-maven-3.3.9
 ENV maven.home $M2_HOME
 ENV M2 $M2_HOME/bin
 ENV PATH $M2:$PATH
+RUN mkdir --parents --mode 777 /root/.mvnrepository
 
 # Set JDK to be 32bit
 COPY set_java $M2


### PR DESCRIPTION
A PV was mounted here on this path before, but it is being removed for
performance reasons. The default perms make it impossible to write and the build
would fail with the error

```
+ mvn org.codehaus.mojo:versions-maven-plugin:2.2:set -U -DnewVersion=1.0.3
Picked up _JAVA_OPTIONS: -Duser.home=/root/ -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m
[ERROR] Could not create local repository at /root/.mvnrepository -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/LocalRepositoryNotAccessibleException
```

Fixes https://github.com/openshiftio/openshift.io/issues/2368